### PR TITLE
improve MongoDb Api compatibility

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,16 +1,18 @@
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel, Field, ConfigDict
+from utils import PyObjectId
+
 
 
 class PetshopModel(BaseModel):
     nome_petshop: str
     descricao: str
-    
+
 
 class UpdatePetshopModel(BaseModel):
     nome_petshop: Optional[str] = None
     descricao: Optional[str] = None
-    
+
     def model_dump(self, **kwargs):
         dict_filtrado = super().model_dump(**kwargs)
         return {campo: valor for campo, valor in dict_filtrado.items() if valor is not None}
@@ -18,11 +20,16 @@ class UpdatePetshopModel(BaseModel):
 
 class PetshopList(BaseModel):
     petshops: List[PetshopModel]
-    
 
-class PetModel (BaseModel):
+
+class PetModel(BaseModel):
+    id: Optional[PyObjectId] = Field(alias="_id", default=None)
     nome_pet: str
     especie: str
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True)
     
 
 class UpdatePetModel(BaseModel):
@@ -34,5 +41,5 @@ class UpdatePetModel(BaseModel):
         return {campo: valor for campo, valor in dict_filtrado.items() if valor is not None}
 
     
-class PetList(BaseModel):
-    pets: List[PetModel]
+class PetList(RootModel):
+    root: List[PetModel]

--- a/routes/pet_route.py
+++ b/routes/pet_route.py
@@ -11,104 +11,83 @@ collection = db['pet']
 @PET_ROUTE.route('/get/all/pet/', methods=['GET'])
 async def get_all_pet(request: Request):
     all_pets = collection.find()
-    
-    if all_pets:
-    
-        pets_formatados = [PetModel(**pet).model_dump() for pet in all_pets]
-        
-        pet_list = PetList(pets=pets_formatados).model_dump()
-        
-        return response.json(pet_list)
-    else:
-        return response.json({"Message": "Nenhum registro de pet encontrado"})
-    
+    return response.json(
+        PetList(root=all_pets).model_dump()
+    )
+
 
 @PET_ROUTE.route('/get/pet/<pet_id>/', methods=['GET'])
 async def get_one_pet(request: Request, pet_id):
     try:
         pet = collection.find_one({"_id": ObjectId(pet_id)})
-        
-        if pet:
-            pet_instance = PetModel(**pet)
-            pet_dict = pet_instance.model_dump()
-            
-            return response.json(pet_dict)
-        else:
-            return response.json({"Pet not found"}, status=404)  
-        
-    except ValidationError as e:       
-        erros = e.errors()
-        
-        return response.json({"Description": erros[0]["type"],
-        "Message error": erros[0]['msg'],
-        })
-    
 
-@PET_ROUTE.route('/create/pet/', methods=['GET','POST'])
+        return response.json(PetModel(**pet).model_dump() if pet else None)
+
+    except ValidationError as e:
+        erros = e.errors()
+
+        return response.json({"Description": erros[0]["type"],
+                              "Message error": erros[0]['msg'],
+                              })
+
+
+@PET_ROUTE.route('/create/pet/', methods=['GET', 'POST'])
 async def create_pet(request: Request):
     try:
-        pet = PetModel(**request.json)
+        pet = PetModel(**request.json).model_dump()
+        collection.insert_one(pet)
 
-        collection.insert_one(pet.model_dump())
+        return response.json({"Message": "Registro adicionado", "Pet adicionado": PetModel(**pet).model_dump()})
 
-        return response.json({"Message":"Registro adicionado", "Pet adicionado": pet.model_dump()})
-    
-    except ValidationError as e:       
+    except ValidationError as e:
         erros = e.errors()
-        
+
         return response.json({"Description": erros[0]["type"],
-        "Message error": erros[0]['msg'],
-        })
-        
+                              "Message error": erros[0]['msg'],
+                              })
+
 
 @PET_ROUTE.route('/update/pet/<pet_id>/', methods=['PUT', 'PATCH', 'GET'])
 async def update_pet(request: Request, pet_id):
-    try:   
+    try:
         pet = collection.find_one({"_id": ObjectId(pet_id)})
-        
-        print(request.method)
-        
+
         if pet:
-            
+
             if request.method == 'PUT':
-        
+
                 pet_instance = PetModel(**request.json)
                 pet_dict = pet_instance.model_dump()
-                
-                collection.update_one({"_id": ObjectId(pet_id)}, {"$set":  pet_dict})
-            
+
+                collection.update_one(
+                    {"_id": ObjectId(pet_id)}, {"$set":  pet_dict})
+
             if request.method == 'PATCH':
                 update_pet_instance = UpdatePetModel(**request.json)
                 update_pet_dict = update_pet_instance.model_dump()
-                
-                collection.update_one({"_id": ObjectId(pet_id)}, {"$set":  update_pet_dict})
-                
+
+                collection.update_one({"_id": ObjectId(pet_id)}, {
+                                      "$set":  update_pet_dict})
+
                 pet = collection.find_one({"_id": ObjectId(pet_id)})
-                
+
                 pet_instance = PetModel(**pet)
                 pet_dict = pet_instance.model_dump()
-                
-        
-            return response.json({"Message":"Registro atualizado", "Pet atualizado": pet_dict})
-        
+
+            return response.json({"Message": "Registro atualizado", "Pet atualizado": pet_dict})
+
         else:
             return response.json({"Pet not found"}, status=404)
-        
-    except ValidationError as e:       
+
+    except ValidationError as e:
         erros = e.errors()
-        
+
         return response.json({"Description": erros[0]["type"],
-        "Message error": erros[0]['msg'],
-        })
+                              "Message error": erros[0]['msg'],
+                              })
+
 
 @PET_ROUTE.route('/delete/pet/<pet_id>/', methods=['GET', 'DELETE'])
-async def delete_one_pet(request: Request, pet_id:str):
-    pet = collection.find_one({"_id": ObjectId(pet_id)})
-    
-    if pet:
-        collection.delete_one(pet)
-        pet_dict = PetModel(**pet).model_dump()
-        
-        return response.json({"Message": "Pet deletado com sucesso", "Pet deletado": pet_dict})
-    else:
-        return response.json({"Petshop not found"}, status=404)
+async def delete_one_pet(request: Request, pet_id: str):
+    collection.delete_one({"_id": ObjectId(pet_id)})
+    return response.json(status=204)

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 from sanic import Sanic
 from sanic.response import json
+from routes import ROUTES
 
 app = Sanic(__name__)
 
@@ -7,8 +8,7 @@ app = Sanic(__name__)
 async def initial(request):
     return json({"hello":"world"})
 
-from routes import ROUTES
 app.blueprint(ROUTES)
 
 if __name__ == '__main__':
-    app.run(host="localhost", port=7777, auto_reload=True)
+    app.run(host="0.0.0.0", port=7777, auto_reload=True)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,29 @@
+from typing import Any
+from pydantic_core import core_schema
+from bson import ObjectId
+
+
+class PyObjectId(str):
+    @classmethod
+    def __get_pydantic_core_schema__(
+            cls, _source_type: Any, _handler: Any
+    ) -> core_schema.CoreSchema:
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.str_schema(),
+            python_schema=core_schema.union_schema([
+                core_schema.is_instance_schema(ObjectId),
+                core_schema.chain_schema([
+                    core_schema.str_schema(),
+                    core_schema.no_info_plain_validator_function(cls.validate),
+                ])
+            ]),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda x: str(x)
+            ),
+        )
+
+    @classmethod
+    def validate(cls, value) -> ObjectId:
+        if not ObjectId.is_valid(value):
+            raise ValueError("Invalid ObjectId")
+        return ObjectId(value)


### PR DESCRIPTION
Changes:
  - Added id field on API response of creation and get operation;
  - Clean some code;

Obs:
  - Find One does not need to return different status code to "Not Found" register on database, return of "null" value is enough;
  - On Find All, When getting response of query, no need to check if list has items, return the parsed list is enough;

Hints:
  - Status code of post("creation of resource") must be 201;
  - No need to create_pet and update_pet handlers be listening on "GET" method;
  - Split update_pet into two handlers, each one must listen to one specific http method;
  - Use some cleaner path name pattern;

Path examples:
  - GET - /petshops -> return list of petshops;  success_code: 200
  - GET - /petshops/<id:str> -> return petshop or null;  success_code: 200
  - POST - /petshops -> create petshop;  success: 201
  - UPDATE - /petshops/<id:str> -> update one petshop by id;  success_code: 200
  - PATCH - /petshops/<id:str> -> patch one petshop by id;  success_code: 200
  - DELETE - /petshops/<id:str> -> delete one petshop by id; success_code: 204
